### PR TITLE
Remove policy files as part of JEP 486

### DIFF
--- a/installers/linux/al2/spec/java-amazon-corretto.spec.template
+++ b/installers/linux/al2/spec/java-amazon-corretto.spec.template
@@ -410,7 +410,6 @@ fi
 %config(noreplace) %{java_home}/conf/sound.properties
 %config(noreplace) %{java_home}/conf/management/jmxremote.access
 %config(noreplace) %{java_home}/conf/management/management.properties
-%config(noreplace) %{java_home}/conf/security/java.policy
 %config(noreplace) %{java_home}/conf/security/java.security
 %config(noreplace) %{java_home}/conf/security/policy/limited/exempt_local.policy
 %config(noreplace) %{java_home}/conf/security/policy/limited/default_local.policy
@@ -418,7 +417,6 @@ fi
 %config(noreplace) %{java_home}/conf/security/policy/unlimited/default_local.policy
 %config(noreplace) %{java_home}/conf/security/policy/unlimited/default_US_export.policy
 %config(noreplace) %{java_home}/lib/security/blocked.certs
-%config(noreplace) %{java_home}/lib/security/default.policy
 %config(noreplace) %{java_home}/lib/security/public_suffix_list.dat
 %dir %{java_home}
 %dir %{java_home}/bin


### PR DESCRIPTION
Thank you for taking the time to help improve OpenJDK and Corretto.

If your pull request concerns a security vulnerability then please do not file it here.
Instead, report the problem by email to aws-security@amazon.com.
(You can find more information regarding security issues at https://aws.amazon.com/security/vulnerability-reporting/.)

Otherwise, if your pull request concerns OpenJDK
and is not specific to Corretto,
then we ask you to redirect your contribution to the OpenJDK project.
See http://openjdk.java.net/contribute/ for details on how to do that.

If your issue is specific to Corretto,
then you are in the right place.
Please fill in the following information about your pull request.

### Description
Builds are looking for .policy files that were removed as part of JEP 486. Remove these from `java-amazon-corretto.spec.template`.
