### PR TITLE
add missing man config files

### DIFF
--- a/installers/linux/al2/spec/java-amazon-corretto.spec.template
+++ b/installers/linux/al2/spec/java-amazon-corretto.spec.template
@@ -403,6 +403,12 @@ fi
 %{java_lib}/libawt_xawt.so
 %{java_lib}/libjawt.so
 %{java_lib}/libsplashscreen.so
+%{java_home}/man/man1/jabswitch.1
+%{java_home}/man/man1/jaccessinspector.1
+%{java_home}/man/man1/jaccesswalker.1
+%{java_home}/man/man1/kinit.1
+%{java_home}/man/man1/klist.1
+%{java_home}/man/man1/ktab.1
 
 %files headless
 %config(noreplace) %{java_home}/conf/logging.properties


### PR DESCRIPTION
Thank you for taking the time to help improve OpenJDK and Corretto.

If your pull request concerns a security vulnerability then please do not file it here.
Instead, report the problem by email to aws-security@amazon.com.
(You can find more information regarding security issues at https://aws.amazon.com/security/vulnerability-reporting/.)

Otherwise, if your pull request concerns OpenJDK
and is not specific to Corretto,
then we ask you to redirect your contribution to the OpenJDK project.
See http://openjdk.java.net/contribute/ for details on how to do that.

If your issue is specific to Corretto,
then you are in the right place.
Please fill in the following information about your pull request.

### Description


### Related issues


### Motivation and context


### How has this been tested?


### Platform information
    Works on OS: [e.g. Amazon Linux 2 only]
    Applies to version [e.g. "11.0.1+13-1" (see output from "java -version")]


### Additional context
