### PR TITLE
Revert "Merge pull request #2 from elifaslan1/24albuild"

### DIFF
--- a/installers/linux/al2/spec/java-amazon-corretto.spec.template
+++ b/installers/linux/al2/spec/java-amazon-corretto.spec.template
@@ -403,12 +403,6 @@ fi
 %{java_lib}/libawt_xawt.so
 %{java_lib}/libjawt.so
 %{java_lib}/libsplashscreen.so
-%{java_home}/man/man1/jabswitch.1
-%{java_home}/man/man1/jaccessinspector.1
-%{java_home}/man/man1/jaccesswalker.1
-%{java_home}/man/man1/kinit.1
-%{java_home}/man/man1/klist.1
-%{java_home}/man/man1/ktab.1
 
 %files headless
 %config(noreplace) %{java_home}/conf/logging.properties


### PR DESCRIPTION
This reverts commit 1d3ceb2b72e73b2e6d991fff4cd8f401039f778a, reversing changes made to d9621fc8f3498e98a3c1a05dc140edff5a04f571.

The windows man pages being generated for linux builds has been resolved and backported from this commit: https://github.com/corretto/corretto-24/commit/3dda904c0d3d9c2866a9fd0946aa3a0cc23794ec. This means we no longer need to include the windows-specific man pages in the `java-amazon-corretto.spec.template` file.
