### PR TITLE
Remove java.policy and default.policy from build.gradle following JEP486

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -77,12 +77,10 @@ allprojects {
             'conf/security/policy/limited/default_US_export.policy',
             'conf/security/policy/unlimited/default_local.policy',
             'conf/security/policy/unlimited/default_US_export.policy',
-            'conf/security/java.policy',
             'conf/security/java.security',
             'conf/management/jmxremote.access',
             'conf/management/management.properties',
             'lib/security/blocked.certs',
-            'lib/security/default.policy',
             'lib/security/public_suffix_list.dat'
             ];
 


### PR DESCRIPTION
Following https://github.com/corretto/corretto-24/issues/6 `build.gradle` was not updated to remove `conf/security/java.policy` and `lib/security/default.policy`. This should have been done as part of https://github.com/corretto/corretto-24/commit/d9621fc8f3498e98a3c1a05dc140edff5a04f571.
