### PR TITLE
Fix the typo in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Please read these files: "LICENSE", "ADDITIONAL_LICENSE_INFO", "ASSEMBLY_EXCEPTI
 ### Branches
 
 _develop_
-: The default branch. The branch that consumes development and patches to upstream [openjdk/jdk:jdk23](https://github.com/openjdk/jdk/tree/jdk24). Corretto builds are generated from this branch.
+: The default branch. The branch that consumes development and patches to upstream [openjdk/jdk:jdk24](https://github.com/openjdk/jdk/tree/jdk24). Corretto builds are generated from this branch.
 
 ### OpenJDK Readme
 ```


### PR DESCRIPTION
Fix the typo in README.md: "jdk23" -> "jdk24"