### PR TITLE
8357193: [VS 2022 17.14] Warning C5287 in debugInit.c: enum type mismatch during build

### DIFF
--- a/make/modules/jdk.jdwp.agent/Lib.gmk
+++ b/make/modules/jdk.jdwp.agent/Lib.gmk
@@ -66,6 +66,7 @@ $(eval $(call SetupJdkLibrary, BUILD_LIBJDWP, \
     DISABLED_WARNINGS_clang_threadControl.c := unused-but-set-variable \
         unused-variable, \
     DISABLED_WARNINGS_clang_utf_util.c := unused-but-set-variable, \
+    DISABLED_WARNINGS_microsoft_debugInit.c := 5287, \
     EXTRA_HEADER_DIRS := \
         include \
         libjdwp/export \


### PR DESCRIPTION
This patch suppresses compiler warning C5287 triggered in debugInit.c when building with Visual Studio 2022 version 17.14 (released a few days ago).

clean backport of https://github.com/openjdk/jdk/pull/25293