### PR TITLE
Fixing CVE table for 24.0.1.9.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,9 +29,9 @@ The following CVEs are addressed in 24.0.1.9.1
 
 | CVE | CVSS | Component |
 |-----|------|-----------|
-| CVE-2025-21587 | security-libs/javax.net.ssl | 7.4 |
-| CVE-2025-30698 | client-libs/2d | 5.6 |
-| CVE-2025-30691 | hotspot/compiler | 4.8 |
+| CVE-2025-21587 | 7.4 | security-libs/javax.net.ssl |
+| CVE-2025-30698 | 5.6 | client-libs/2d |
+| CVE-2025-30691 | 4.8 | hotspot/compiler |
 
 ## Corretto version: 24.0.0.36.3
 Release Date: March 19, 2025


### PR DESCRIPTION
Fixing typo in `CHANGELOG.md` for latest release, reordering columns in CVE table to align correctly.